### PR TITLE
stream: Add helper APIs for AWS

### DIFF
--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -17,4 +17,17 @@ func TestParseFCS(t *testing.T) {
 	assert.Equal(t, stream.Stream, "stable")
 	assert.Equal(t, stream.Architectures["x86_64"].Artifacts["metal"].Formats["raw.xz"].Disk.Sha256, "2848b111a6917455686f38a3ce64d2321c33809b9cf796c5f6804b1c02d79d9d")
 	assert.Equal(t, stream.Architectures["x86_64"].Images.Aws.Regions["us-east-2"].Image, "ami-091b0dbc05fe2dc06")
+
+	ami, err := stream.GetAMI("x86_64", "us-east-2")
+	assert.Nil(t, err)
+	assert.Equal(t, ami, "ami-091b0dbc05fe2dc06")
+
+	// I hope I live to see the day when we might change this code to test for success and not error
+	_, err = stream.GetAMI("x86_64", "mars-1")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "stream:stable arch:x86_64: No AWS images in region mars-1")
+
+	_, err = stream.GetAMI("aarch64", "us-east-2")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "stream:stable does not have architecture 'aarch64'")
 }

--- a/stream/stream_utils.go
+++ b/stream/stream_utils.go
@@ -1,0 +1,47 @@
+package stream
+
+import "fmt"
+
+// formatPrefix describes a stream+architecture combination, intended for prepending to error messages
+func (st *Stream) formatPrefix(archname string) string {
+	return fmt.Sprintf("stream:%s arch:%s", st.Stream, archname)
+}
+
+// GetArchitecture loads the architecture-specific builds from a stream,
+// with a useful descriptive error message if the architecture is not found.
+func (st *Stream) GetArchitecture(archname string) (*Arch, error) {
+	archdata, ok := st.Architectures[archname]
+	if !ok {
+		return nil, fmt.Errorf("stream:%s does not have architecture '%s'", st.Stream, archname)
+	}
+	return &archdata, nil
+}
+
+// GetAwsRegionImage returns the release data (AMI and release ID) for a particular
+// architecture and region.
+func (st *Stream) GetAwsRegionImage(archname, region string) (*AwsRegionImage, error) {
+	starch, err := st.GetArchitecture(archname)
+	if err != nil {
+		return nil, err
+	}
+	awsimages := starch.Images.Aws
+	if awsimages == nil {
+		return nil, fmt.Errorf("%s: No AWS images", st.formatPrefix(archname))
+	}
+	var regionVal AwsRegionImage
+	var ok bool
+	if regionVal, ok = awsimages.Regions[region]; !ok {
+		return nil, fmt.Errorf("%s: No AWS images in region %s", st.formatPrefix(archname), region)
+	}
+
+	return &regionVal, nil
+}
+
+// GetAMI returns the AWS machine image for a particular architecture and region.
+func (st *Stream) GetAMI(archname, region string) (string, error) {
+	regionVal, err := st.GetAwsRegionImage(archname, region)
+	if err != nil {
+		return "", err
+	}
+	return regionVal.Image, nil
+}


### PR DESCRIPTION
In updating openshift-install to use this I really wanted to have
nice error prefixing if a particular architecture/region wasn't
found.  These new APIs handle that and also are what basically
everyone interacting with AWS will want.

(I may update the example to use them in the future, but it's
 also useful to show traversing the "raw" data structures)