### PR TITLE
stream: Make FormatPrefix public

### DIFF
--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -22,6 +22,8 @@ func TestParseFCS(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, ami, "ami-091b0dbc05fe2dc06")
 
+	assert.Equal(t, "stream:stable arch:x86_64", stream.FormatPrefix("x86_64"))
+
 	// I hope I live to see the day when we might change this code to test for success and not error
 	_, err = stream.GetAMI("x86_64", "mars-1")
 	assert.NotNil(t, err)

--- a/stream/stream_utils.go
+++ b/stream/stream_utils.go
@@ -2,8 +2,8 @@ package stream
 
 import "fmt"
 
-// formatPrefix describes a stream+architecture combination, intended for prepending to error messages
-func (st *Stream) formatPrefix(archname string) string {
+// FormatPrefix describes a stream+architecture combination, intended for prepending to error messages
+func (st *Stream) FormatPrefix(archname string) string {
 	return fmt.Sprintf("stream:%s arch:%s", st.Stream, archname)
 }
 
@@ -26,12 +26,12 @@ func (st *Stream) GetAwsRegionImage(archname, region string) (*AwsRegionImage, e
 	}
 	awsimages := starch.Images.Aws
 	if awsimages == nil {
-		return nil, fmt.Errorf("%s: No AWS images", st.formatPrefix(archname))
+		return nil, fmt.Errorf("%s: No AWS images", st.FormatPrefix(archname))
 	}
 	var regionVal AwsRegionImage
 	var ok bool
 	if regionVal, ok = awsimages.Regions[region]; !ok {
-		return nil, fmt.Errorf("%s: No AWS images in region %s", st.formatPrefix(archname), region)
+		return nil, fmt.Errorf("%s: No AWS images in region %s", st.FormatPrefix(archname), region)
 	}
 
 	return &regionVal, nil


### PR DESCRIPTION
I actually also want this for e.g. GCP, let's just make the
API public so it's easy to use outside.