### PR TITLE
Add an uncompressed sha256 to release and streams

### DIFF
--- a/release/release.go
+++ b/release/release.go
@@ -88,9 +88,10 @@ type ImageFormat struct {
 
 // Artifact represents one image file, plus its metadata
 type Artifact struct {
-	Location  string `json:"location"`
-	Signature string `json:"signature"`
-	Sha256    string `json:"sha256"`
+	Location           string `json:"location"`
+	Signature          string `json:"signature"`
+	Sha256             string `json:"sha256"`
+	UncompressedSha256 string `json:"uncompressed-sha256,omitempty"`
 }
 
 // CloudImage generic image detail

--- a/release/translate.go
+++ b/release/translate.go
@@ -9,9 +9,10 @@ func mapArtifact(ra *Artifact) *stream.Artifact {
 		return nil
 	}
 	return &stream.Artifact{
-		Location:  ra.Location,
-		Signature: ra.Signature,
-		Sha256:    ra.Sha256,
+		Location:           ra.Location,
+		Signature:          ra.Signature,
+		Sha256:             ra.Sha256,
+		UncompressedSha256: ra.UncompressedSha256,
 	}
 }
 

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -37,9 +37,10 @@ type ImageFormat struct {
 
 // Artifact represents one image file, plus its metadata
 type Artifact struct {
-	Location  string `json:"location"`
-	Signature string `json:"signature"`
-	Sha256    string `json:"sha256"`
+	Location           string `json:"location"`
+	Signature          string `json:"signature"`
+	Sha256             string `json:"sha256"`
+	UncompressedSha256 string `json:"uncompressed-sha256"`
 }
 
 // Images contains images available in cloud providers


### PR DESCRIPTION
Moving this from
https://github.com/coreos/coreos-assembler/pull/2000#issuecomment-763152177

I'm trying to port openshift-install to streams, and it currently
is using the uncompressed sha256 - and further it's exposed in
some cases to users.

Since compression isn't always easily reproducible, I think what
cosa is doing in having both checksums is a good thing; might
as well do belt-and-suspenders.

To emphasize we already have this data from the cosa
metadata, this is just adding support for it to the stream
and release metadata.