### PR TITLE
Add an `arch` package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PKGS := release stream fedoracoreos
+PKGS := arch release stream fedoracoreos
 
 build:
 	for pkg in $(PKGS); do (cd $$pkg && go build -mod=vendor); done

--- a/arch/arch.go
+++ b/arch/arch.go
@@ -1,0 +1,48 @@
+// package arch contains mappings between the Golang architecture and
+// the RPM architecture used by Fedora CoreOS and derivatives.
+package arch
+
+import "runtime"
+
+type mapping struct {
+	rpmArch string
+	goArch  string
+}
+
+// If an architecture isn't defined here, we assume it's
+// pass through.
+var translations = []mapping{
+	{
+		rpmArch: "x86_64",
+		goArch:  "amd64",
+	},
+	{
+		rpmArch: "aarch64",
+		goArch:  "arm64",
+	},
+}
+
+// CurrentRpmArch returns the current architecture in RPM terms.
+func CurrentRpmArch() string {
+	return RpmArch(runtime.GOARCH)
+}
+
+// RpmArch translates a Go architecture to RPM.
+func RpmArch(goarch string) string {
+	for _, m := range translations {
+		if m.goArch == goarch {
+			return m.rpmArch
+		}
+	}
+	return goarch
+}
+
+// GoArch translates an RPM architecture to Go.
+func GoArch(rpmarch string) string {
+	for _, m := range translations {
+		if m.rpmArch == rpmarch {
+			return m.goArch
+		}
+	}
+	return rpmarch
+}

--- a/arch/arch_test.go
+++ b/arch/arch_test.go
@@ -1,0 +1,19 @@
+// package arch contains mappings between the Golang architecture and
+// the RPM architecture used by Fedora CoreOS and derivatives.
+package arch
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapping(t *testing.T) {
+	// Validate bidirectional mapping for current architecture
+	assert.Equal(t, GoArch(CurrentRpmArch()), runtime.GOARCH)
+
+	assert.Equal(t, GoArch("x86_64"), "amd64")
+	assert.Equal(t, GoArch("aarch64"), "arm64")
+	assert.Equal(t, GoArch("ppc64le"), "ppc64le")
+}


### PR DESCRIPTION
Many users of this package will want to translate between
Go and RPM architectures.  This moves code that exists
in coreos-assembler (and can then be deleted from there):
https://github.com/coreos/coreos-assembler/blob/master/mantle/system/arch.go