### PR TITLE
stream: use omitempty for new UncompressedSha256

### DIFF
--- a/stream/stream.go
+++ b/stream/stream.go
@@ -40,7 +40,7 @@ type Artifact struct {
 	Location           string `json:"location"`
 	Signature          string `json:"signature"`
 	Sha256             string `json:"sha256"`
-	UncompressedSha256 string `json:"uncompressed-sha256"`
+	UncompressedSha256 string `json:"uncompressed-sha256,omitempty"`
 }
 
 // Images contains images available in cloud providers


### PR DESCRIPTION
There's lots of artifacts (like the initramfs and rootfs) which don't
have this field in the original `meta.json`. We don't want to emit
`UncompressedSha256` keys for those.