### PR TITLE
Add RHELCoreOSExtensions with Azure image URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PKGS := arch release stream fedoracoreos
+PKGS := arch release stream stream/rhcos release/rhcos fedoracoreos
 
 build:
 	for pkg in $(PKGS); do (cd $$pkg && go build -mod=vendor); done

--- a/release/release.go
+++ b/release/release.go
@@ -4,6 +4,10 @@
 // with streams instead.
 package release
 
+import (
+	relrhcos "github.com/coreos/stream-metadata-go/release/rhcos"
+)
+
 // Index models the release index:
 // https://github.com/coreos/fedora-coreos-tracker/tree/master/metadata/release-index
 type Index struct {
@@ -41,8 +45,9 @@ type Metadata struct {
 
 // Arch release details
 type Arch struct {
-	Commit string `json:"commit"`
-	Media  Media  `json:"media"`
+	Commit               string               `json:"commit"`
+	Media                Media                `json:"media"`
+	RHELCoreOSExtensions *relrhcos.Extensions `json:"rhel-coreos-extensions,omitempty"`
 }
 
 // Media contains release details for various platforms

--- a/release/rhcos/rhcos.go
+++ b/release/rhcos/rhcos.go
@@ -1,0 +1,14 @@
+package rhcos
+
+// Extensions is data specific to Red Hat Enterprise Linux CoreOS
+type Extensions struct {
+	AzureDisk *AzureDisk `json:"azure-disk,omitempty"`
+}
+
+// AzureDisk represents an Azure cloud image.
+type AzureDisk struct {
+	// URL to an image already stored in Azure infrastructure
+	// that can be copied into an image gallery.  Avoid creating VMs directly
+	// from this URL as that may lead to performance limitations.
+	URL string `json:"url,omitempty"`
+}

--- a/stream/rhcos/rhcos.go
+++ b/stream/rhcos/rhcos.go
@@ -1,0 +1,18 @@
+package rhcos
+
+// Extensions is data specific to Red Hat Enterprise Linux CoreOS
+type Extensions struct {
+	AzureDisk *AzureDisk `json:"azure-disk,omitempty"`
+}
+
+// AzureDisk represents an Azure disk image that can be imported
+// into an image gallery or otherwise replicated, and then used
+// as a boot source for virtual machines.
+type AzureDisk struct {
+	// Release is the source release version
+	Release string `json:"release"`
+	// URL to an image already stored in Azure infrastructure
+	// that can be copied into an image gallery.  Avoid creating VMs directly
+	// from this URL as that may lead to performance limitations.
+	URL string `json:"url,omitempty"`
+}

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -3,6 +3,10 @@
 // this API to find cloud images, bare metal disk images, etc.
 package stream
 
+import (
+	"github.com/coreos/stream-metadata-go/stream/rhcos"
+)
+
 // Stream contains artifacts available in a stream
 type Stream struct {
 	Stream        string          `json:"stream"`
@@ -19,6 +23,8 @@ type Metadata struct {
 type Arch struct {
 	Artifacts map[string]PlatformArtifacts `json:"artifacts"`
 	Images    Images                       `json:"images,omitempty"`
+	// RHELCoreOSExtensions is data specific to Red Hat Enterprise Linux CoreOS
+	RHELCoreOSExtensions *rhcos.Extensions `json:"rhel-coreos-extensions,omitempty"`
 }
 
 // PlatformArtifacts contains images for a platform


### PR DESCRIPTION
This contains just a URL for now because that's all
the current RHCOS cosa metadata has.  I'm trying
to add e.g. the Azure Blob storage md5 information as
well as the full size+sha256, but in practice this
data is just the uncompressed VHD; anyone who wants
to do "offline" verification outside of Azure can
replicate that.

For FCOS we may end up uploading the image too,
though we hope there to end up in the Marketplace.

For now, let's stick this off an explicit extension area.

Closes: https://github.com/coreos/stream-metadata-go/issues/13