### PR TITLE
FormatPrefix: Just use <streamname>/<arch>

### DIFF
--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -22,12 +22,12 @@ func TestParseFCS(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, ami, "ami-091b0dbc05fe2dc06")
 
-	assert.Equal(t, "stream:stable arch:x86_64", stream.FormatPrefix("x86_64"))
+	assert.Equal(t, "stable/x86_64", stream.FormatPrefix("x86_64"))
 
 	// I hope I live to see the day when we might change this code to test for success and not error
 	_, err = stream.GetAMI("x86_64", "mars-1")
 	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "stream:stable arch:x86_64: No AWS images in region mars-1")
+	assert.Contains(t, err.Error(), "stable/x86_64: No AWS images in region mars-1")
 
 	_, err = stream.GetAMI("aarch64", "us-east-2")
 	assert.NotNil(t, err)

--- a/stream/stream_utils.go
+++ b/stream/stream_utils.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // FormatPrefix describes a stream+architecture combination, intended for prepending to error messages
 func (st *Stream) FormatPrefix(archname string) string {
-	return fmt.Sprintf("stream:%s arch:%s", st.Stream, archname)
+	return fmt.Sprintf("%s/%s", st.Stream, archname)
 }
 
 // GetArchitecture loads the architecture-specific builds from a stream,


### PR DESCRIPTION
Came up in review of https://github.com/openshift/installer/pull/4582#discussion_r582452663

Since error prefixing will use `:`, let's avoid ambiguity.  It's
going to be generally obvious from context what a stream name
and architecture are (particularly the architecture, everyone
knows `x86_64` and `aarch64` if they're provisioning a machine
for them).