### PR TITLE
stream: Add a high level API to find a disk

### DIFF
--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -32,4 +32,18 @@ func TestParseFCS(t *testing.T) {
 	_, err = stream.GetAMI("aarch64", "us-east-2")
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "stream:stable does not have architecture 'aarch64'")
+
+	a, err := stream.QueryDisk("x86_64", "metal", "iso")
+	assert.Nil(t, err)
+	assert.Equal(t, a.Location, "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20201201.3.0/x86_64/fedora-coreos-33.20201201.3.0-live.x86_64.iso")
+
+	_, err = stream.QueryDisk("x86_64", "metal", "nosuchthing")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "disk not found")
+	_, err = stream.QueryDisk("x86_64", "mysterious-obelisk", "rune")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "artifact 'mysterious-obelisk' not found")
+	_, err = stream.QueryDisk("nonarch", "", "nosuchthing")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "does not have architecture 'nonarch'")
 }

--- a/stream/stream_utils.go
+++ b/stream/stream_utils.go
@@ -45,3 +45,21 @@ func (st *Stream) GetAMI(archname, region string) (string, error) {
 	}
 	return regionVal.Image, nil
 }
+
+// QueryDisk finds the singleton disk artifact for a given format and architecture.
+func (st *Stream) QueryDisk(architectureName, artifactName, formatName string) (*Artifact, error) {
+	arch, err := st.GetArchitecture(architectureName)
+	if err != nil {
+		return nil, err
+	}
+	artifacts := arch.Artifacts[artifactName]
+	if artifacts.Release == "" {
+		return nil, fmt.Errorf("%s: artifact '%s' not found", st.FormatPrefix(architectureName), artifactName)
+	}
+	format := artifacts.Formats[formatName]
+	if format.Disk == nil {
+		return nil, fmt.Errorf("%s: artifact '%s' format '%s' disk not found", st.FormatPrefix(architectureName), artifactName, formatName)
+	}
+
+	return format.Disk, nil
+}


### PR DESCRIPTION
Almost everything *except* `metal` is a disk, so this little
query API is convenient, plus traversing the chain requires
verbose error handling for callers that they shouldn't
need to replcate.