### PR TITLE
fedoracoreos: Add FetchStream API

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -4,10 +4,7 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"os"
 
 	"github.com/coreos/stream-metadata-go/fedoracoreos"
@@ -54,30 +51,18 @@ func printAMI(fcosstable stream.Stream) error {
 }
 
 func run() error {
-	streamurl := fedoracoreos.GetStreamURL(fedoracoreos.StreamStable)
-	resp, err := http.Get(streamurl.String())
-	if err != nil {
-		return err
-	}
-	body, err := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
-	if err != nil {
-		return err
-	}
-
-	var fcosstable stream.Stream
-	err = json.Unmarshal(body, &fcosstable)
-	if err != nil {
-		return err
-	}
 	if len(os.Args) != 2 {
 		return fmt.Errorf("usage: example aws-ami|download-iso")
 	}
 	arg := os.Args[1]
+	fcosstable, err := fedoracoreos.FetchStream(fedoracoreos.StreamStable)
+	if err != nil {
+		return err
+	}
 	if arg == "aws-ami" {
-		return printAMI(fcosstable)
+		return printAMI(*fcosstable)
 	} else if arg == "download-iso" {
-		return downloadISO(fcosstable)
+		return downloadISO(*fcosstable)
 	} else {
 		return fmt.Errorf("invalid operation %s", arg)
 	}

--- a/fedoracoreos/fcos.go
+++ b/fedoracoreos/fcos.go
@@ -4,10 +4,14 @@
 package fedoracoreos
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"net/url"
 
 	"github.com/coreos/stream-metadata-go/fedoracoreos/internals"
+	"github.com/coreos/stream-metadata-go/stream"
 )
 
 const (
@@ -24,4 +28,33 @@ func GetStreamURL(stream string) url.URL {
 	u := internals.GetBaseURL()
 	u.Path = fmt.Sprintf("streams/%s.json", stream)
 	return u
+}
+
+func getStream(u url.URL) (*stream.Stream, error) {
+	resp, err := http.Get(u.String())
+	if err != nil {
+		return nil, err
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	var s stream.Stream
+	err = json.Unmarshal(body, &s)
+	if err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+// FetchStream fetches and parses stream metadata for a stream
+func FetchStream(streamName string) (*stream.Stream, error) {
+	u := GetStreamURL(streamName)
+	s, err := getStream(u)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch stream %s: %w", streamName, err)
+	}
+	return s, nil
 }


### PR DESCRIPTION
Most callers will want this.  Additionally, if we ever add
more integrity for the stream such as GPG signing, this will
be the place to do it.

xref https://github.com/coreos/fedora-coreos-tracker/issues/774