### PR TITLE
Download: Fix path/filepath mixup

### DIFF
--- a/stream/artifact_utils.go
+++ b/stream/artifact_utils.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"path/filepath"
 
 	"github.com/google/renameio"
 )
@@ -51,7 +52,7 @@ func (a *Artifact) Download(destdir string) (string, error) {
 		return "", err
 	}
 	name := path.Base(loc.Path)
-	destfile := path.Join(destdir, name)
+	destfile := filepath.Join(destdir, name)
 	w, err := renameio.TempFile("", destfile)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
When reading the URL we need to use `path` for Windows, but
local files are `filepath`.