### PR TITLE
workflows: test on Go 1.16

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
     name: test build
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x]
+        go-version: [1.14.x, 1.15.x, 1.16.x]
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x


### PR DESCRIPTION
Branch protection will need to be updated.