### PR TITLE
stream: add `Metadata.Generator` field

### DIFF
--- a/stream/fixtures/fcos-stream.json
+++ b/stream/fixtures/fcos-stream.json
@@ -1,7 +1,8 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2020-12-17T14:18:43Z"
+        "last-modified": "2020-12-17T14:18:43Z",
+        "generator": "fedora-coreos-stream-generator v0"
     },
     "architectures": {
         "x86_64": {

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -17,6 +17,7 @@ type Stream struct {
 // Metadata for a release or stream
 type Metadata struct {
 	LastModified string `json:"last-modified"`
+	Generator    string `json:"generator,omitempty"`
 }
 
 // Arch contains release details for a particular hardware architecture


### PR DESCRIPTION
Allow recording the software that generated the file.

Spec update: https://github.com/coreos/fedora-coreos-tracker/pull/962