### PR TITLE
stream: make `Artifact.Signature` omitempty

### DIFF
--- a/stream/stream.go
+++ b/stream/stream.go
@@ -45,7 +45,7 @@ type ImageFormat struct {
 // Artifact represents one image file, plus its metadata
 type Artifact struct {
 	Location           string `json:"location"`
-	Signature          string `json:"signature"`
+	Signature          string `json:"signature,omitempty"`
 	Sha256             string `json:"sha256"`
 	UncompressedSha256 string `json:"uncompressed-sha256,omitempty"`
 }


### PR DESCRIPTION
RHCOS artifacts are not signed.  If we omit signature URLs from the stream metadata, we currently get a field with an empty string as a value.  Since artifacts will likely still be unsigned for a while, acquiesce to reality and correctly omit the field.

xref https://github.com/openshift/installer/pull/5268