### PR TITLE
Add support for IBMCloud/PowerVS images

### DIFF
--- a/release/release.go
+++ b/release/release.go
@@ -52,19 +52,20 @@ type Arch struct {
 
 // Media contains release details for various platforms
 type Media struct {
-	Aliyun       *PlatformAliyun `json:"aliyun"`
-	Aws          *PlatformAws    `json:"aws"`
-	Azure        *PlatformBase   `json:"azure"`
-	AzureStack   *PlatformBase   `json:"azurestack"`
-	Digitalocean *PlatformBase   `json:"digitalocean"`
-	Exoscale     *PlatformBase   `json:"exoscale"`
-	Gcp          *PlatformGcp    `json:"gcp"`
-	Ibmcloud     *PlatformBase   `json:"ibmcloud"`
-	Metal        *PlatformBase   `json:"metal"`
-	Openstack    *PlatformBase   `json:"openstack"`
-	Qemu         *PlatformBase   `json:"qemu"`
-	Vmware       *PlatformBase   `json:"vmware"`
-	Vultr        *PlatformBase   `json:"vultr"`
+	Aliyun       *PlatformAliyun   `json:"aliyun"`
+	Aws          *PlatformAws      `json:"aws"`
+	Azure        *PlatformBase     `json:"azure"`
+	AzureStack   *PlatformBase     `json:"azurestack"`
+	Digitalocean *PlatformBase     `json:"digitalocean"`
+	Exoscale     *PlatformBase     `json:"exoscale"`
+	Gcp          *PlatformGcp      `json:"gcp"`
+	Ibmcloud     *PlatformIBMCloud `json:"ibmcloud"`
+	Metal        *PlatformBase     `json:"metal"`
+	Openstack    *PlatformBase     `json:"openstack"`
+	PowerVS      *PlatformIBMCloud `json:"powervs"`
+	Qemu         *PlatformBase     `json:"qemu"`
+	Vmware       *PlatformBase     `json:"vmware"`
+	Vultr        *PlatformBase     `json:"vultr"`
 }
 
 // PlatformBase with no cloud images
@@ -88,6 +89,12 @@ type PlatformAws struct {
 type PlatformGcp struct {
 	PlatformBase
 	Image *GcpImage `json:"image"`
+}
+
+// PlatformIBMCloud IBMCloud/PowerVS image detail
+type PlatformIBMCloud struct {
+	PlatformBase
+	Images map[string]IBMCloudImage `json:"images"`
 }
 
 // ImageFormat contains all artifacts for a single OS image
@@ -116,4 +123,11 @@ type GcpImage struct {
 	Project string `json:"project,omitempty"`
 	Family  string `json:"family,omitempty"`
 	Name    string `json:"name,omitempty"`
+}
+
+// IBMCloudImage represents an IBMCloud/PowerVS cloud object - which is an ova image for PowerVS and a qcow for IBMCloud in the cloud object storage bucket
+type IBMCloudImage struct {
+	Object string `json:"object"`
+	Bucket string `json:"bucket"`
+	Url    string `json:"url"`
 }

--- a/release/translate.go
+++ b/release/translate.go
@@ -149,6 +149,22 @@ func (releaseArch *Arch) toStreamArch(rel *Release) stream.Arch {
 			Release: rel.Release,
 			Formats: mapFormats(releaseArch.Media.Ibmcloud.Artifacts),
 		}
+		ibmcloudObjects := stream.ReplicatedObject{
+			Regions: make(map[string]stream.RegionObject),
+		}
+		if releaseArch.Media.Ibmcloud.Images != nil {
+			for region, object := range releaseArch.Media.Ibmcloud.Images {
+				ri := stream.RegionObject{
+					Release: rel.Release,
+					Object:  object.Object,
+					Bucket:  object.Bucket,
+					Url:     object.Url,
+				}
+				ibmcloudObjects.Regions[region] = ri
+
+			}
+			cloudImages.Ibmcloud = &ibmcloudObjects
+		}
 	}
 
 	// if releaseArch.Media.Packet != nil {
@@ -166,6 +182,29 @@ func (releaseArch *Arch) toStreamArch(rel *Release) stream.Arch {
 		artifacts["openstack"] = stream.PlatformArtifacts{
 			Release: rel.Release,
 			Formats: mapFormats(releaseArch.Media.Openstack.Artifacts),
+		}
+	}
+
+	if releaseArch.Media.PowerVS != nil {
+		artifacts["powervs"] = stream.PlatformArtifacts{
+			Release: rel.Release,
+			Formats: mapFormats(releaseArch.Media.PowerVS.Artifacts),
+		}
+		powervsObjects := stream.ReplicatedObject{
+			Regions: make(map[string]stream.RegionObject),
+		}
+		if releaseArch.Media.PowerVS.Images != nil {
+			for region, object := range releaseArch.Media.PowerVS.Images {
+				ri := stream.RegionObject{
+					Release: rel.Release,
+					Object:  object.Object,
+					Bucket:  object.Bucket,
+					Url:     object.Url,
+				}
+				powervsObjects.Regions[region] = ri
+
+			}
+			cloudImages.PowerVS = &powervsObjects
 		}
 	}
 

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -52,9 +52,11 @@ type Artifact struct {
 
 // Images contains images available in cloud providers
 type Images struct {
-	Aliyun *ReplicatedImage `json:"aliyun,omitempty"`
-	Aws    *AwsImage        `json:"aws,omitempty"`
-	Gcp    *GcpImage        `json:"gcp,omitempty"`
+	Aliyun   *ReplicatedImage  `json:"aliyun,omitempty"`
+	Aws      *AwsImage         `json:"aws,omitempty"`
+	Gcp      *GcpImage         `json:"gcp,omitempty"`
+	Ibmcloud *ReplicatedObject `json:"ibmcloud,omitempty"`
+	PowerVS  *ReplicatedObject `json:"powervs,omitempty"`
 }
 
 // ReplicatedImage represents an image in all regions of an AWS-like cloud
@@ -79,4 +81,17 @@ type GcpImage struct {
 	Project string `json:"project,omitempty"`
 	Family  string `json:"family,omitempty"`
 	Name    string `json:"name,omitempty"`
+}
+
+// ReplicatedObject represents an object in all regions of an IBMCloud-like cloud
+type ReplicatedObject struct {
+	Regions map[string]RegionObject `json:"regions,omitempty"`
+}
+
+// RegionObject represents an IBMCloud/PowerVS cloud image
+type RegionObject struct {
+	Release string `json:"release"`
+	Object  string `json:"object"`
+	Bucket  string `json:"bucket"`
+	Url     string `json:"url"`
 }


### PR DESCRIPTION
Today we generate metadata for PowerVS in RHCOS, and we would need this to be updated in the installer in the near future, hence this change. IBMCloud and PowerVS have the same format although as of today there are no IBMCloud objects being generated. The naming here is to use "object" instead of image since these are not traditional bootimages like in other clouds.

FCOS is still waiting on ppc64le hardware to have P images generated so could not add any tests related to this.