### PR TITLE
stream: add release field to `GcpImage`

### DIFF
--- a/release/release.go
+++ b/release/release.go
@@ -113,7 +113,7 @@ type CloudImage struct {
 
 // GcpImage represents a GCP cloud image
 type GcpImage struct {
-	Project string `json:"project,omitempty"`
+	Project string `json:"project"`
 	Family  string `json:"family,omitempty"`
-	Name    string `json:"name,omitempty"`
+	Name    string `json:"name"`
 }

--- a/release/translate.go
+++ b/release/translate.go
@@ -124,6 +124,7 @@ func (releaseArch *Arch) toStreamArch(rel *Release) stream.Arch {
 
 		if releaseArch.Media.Gcp.Image != nil {
 			cloudImages.Gcp = &stream.GcpImage{
+				Release: rel.Release,
 				Name:    releaseArch.Media.Gcp.Image.Name,
 				Family:  releaseArch.Media.Gcp.Image.Family,
 				Project: releaseArch.Media.Gcp.Image.Project,

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -76,7 +76,7 @@ type AwsRegionImage = RegionImage
 
 // GcpImage represents a GCP cloud image
 type GcpImage struct {
-	Project string `json:"project,omitempty"`
+	Project string `json:"project"`
 	Family  string `json:"family,omitempty"`
-	Name    string `json:"name,omitempty"`
+	Name    string `json:"name"`
 }

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -76,6 +76,7 @@ type AwsRegionImage = RegionImage
 
 // GcpImage represents a GCP cloud image
 type GcpImage struct {
+	Release string `json:"release"`
 	Project string `json:"project"`
 	Family  string `json:"family,omitempty"`
 	Name    string `json:"name"`


### PR DESCRIPTION
Since the image name is version-specific, we should include a release field here to record the corresponding OS version.  Stream metadata supports version skew between different platforms (e.g. to avoid a platform-specific regression in a release) and we're generally explicit about the version of each artifact.

While we're here, drop `omitempty` from mandatory `GcpImage` fields.  It's harmless, but implies that they're optional.