### PR TITLE
workflows: build and test on macOS and Windows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,13 @@ jobs:
     strategy:
       matrix:
         go-version: [1.15.x, 1.16.x, 1.17.x]
-    runs-on: ubuntu-latest
+        os: [ubuntu-latest]
+        include:
+        - go-version: 1.17.x
+          os: macos-latest
+        - go-version: 1.17.x
+          os: windows-latest
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
@@ -29,6 +35,7 @@ jobs:
       run: make test
     - name: Run linter
       uses: golangci/golangci-lint-action@v2
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       with:
         version: v1.42.0
         args: -E=gofmt --timeout=30m0s


### PR DESCRIPTION
To reduce CI resources, skip linting on both platforms, and test both only on the latest supported Go.