### PR TITLE
Minor cleanups on kubevirt related structs

### DIFF
--- a/stream/stream.go
+++ b/stream/stream.go
@@ -51,7 +51,7 @@ type Artifact struct {
 }
 
 type KubeVirtContainerDisk struct {
-	Image string `json:"image,omitempty"`
+	Image string `json:"image"`
 }
 
 // Images contains images available in cloud providers
@@ -60,8 +60,8 @@ type Images struct {
 	Aws      *AwsImage              `json:"aws,omitempty"`
 	Gcp      *GcpImage              `json:"gcp,omitempty"`
 	Ibmcloud *ReplicatedObject      `json:"ibmcloud,omitempty"`
-	PowerVS  *ReplicatedObject      `json:"powervs,omitempty"`
 	KubeVirt *KubeVirtContainerDisk `json:"kubevirt,omitempty"`
+	PowerVS  *ReplicatedObject      `json:"powervs,omitempty"`
 }
 
 // ReplicatedImage represents an image in all regions of an AWS-like cloud


### PR DESCRIPTION
* Remove `omitempty` from Image string
* Restore alphabetical order in the Images struct