### PR TITLE
Use generic structs for KubeVirt; rename `Region*` to `Single*`

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -41,7 +41,7 @@ func printAMI(fcosstable stream.Stream) error {
 	if awsimages == nil {
 		return fmt.Errorf("No %s AWS images in stream", targetArch)
 	}
-	var regionVal stream.AwsRegionImage
+	var regionVal stream.SingleImage
 	if regionVal, ok = awsimages.Regions[region]; !ok {
 		return fmt.Errorf("No %s AWS images in region %s", targetArch, region)
 	}

--- a/release/release.go
+++ b/release/release.go
@@ -102,7 +102,7 @@ type PlatformIBMCloud struct {
 // PlatformKubeVirt containerDisk metadata
 type PlatformKubeVirt struct {
 	PlatformBase
-	Image *KubeVirtContainerDisk `json:"image"`
+	Image *CloudImage `json:"image"`
 }
 
 // ImageFormat contains all artifacts for a single OS image
@@ -138,9 +138,4 @@ type IBMCloudImage struct {
 	Object string `json:"object"`
 	Bucket string `json:"bucket"`
 	Url    string `json:"url"`
-}
-
-// KubeVirtContainerDisk describes a disk image inside a container which can be consumed by a KubeVirt based platform
-type KubeVirtContainerDisk struct {
-	Image string `json:"image,omitempty"`
 }

--- a/release/translate.go
+++ b/release/translate.go
@@ -46,12 +46,12 @@ func (releaseArch *Arch) toStreamArch(rel *Release) stream.Arch {
 			Formats: mapFormats(releaseArch.Media.Aliyun.Artifacts),
 		}
 		aliyunImages := stream.ReplicatedImage{
-			Regions: make(map[string]stream.RegionImage),
+			Regions: make(map[string]stream.SingleImage),
 		}
 		if releaseArch.Media.Aliyun.Images != nil {
 			for region, image := range releaseArch.Media.Aliyun.Images {
-				ri := stream.RegionImage{Release: rel.Release, Image: image.Image}
-				aliyunImages.Regions[region] = ri
+				si := stream.SingleImage{Release: rel.Release, Image: image.Image}
+				aliyunImages.Regions[region] = si
 
 			}
 			cloudImages.Aliyun = &aliyunImages
@@ -63,13 +63,13 @@ func (releaseArch *Arch) toStreamArch(rel *Release) stream.Arch {
 			Release: rel.Release,
 			Formats: mapFormats(releaseArch.Media.Aws.Artifacts),
 		}
-		awsAmis := stream.AwsImage{
-			Regions: make(map[string]stream.AwsRegionImage),
+		awsAmis := stream.ReplicatedImage{
+			Regions: make(map[string]stream.SingleImage),
 		}
 		if releaseArch.Media.Aws.Images != nil {
 			for region, ami := range releaseArch.Media.Aws.Images {
-				ri := stream.AwsRegionImage{Release: rel.Release, Image: ami.Image}
-				awsAmis.Regions[region] = ri
+				si := stream.SingleImage{Release: rel.Release, Image: ami.Image}
+				awsAmis.Regions[region] = si
 
 			}
 			cloudImages.Aws = &awsAmis
@@ -163,17 +163,17 @@ func (releaseArch *Arch) toStreamArch(rel *Release) stream.Arch {
 			Formats: mapFormats(releaseArch.Media.Ibmcloud.Artifacts),
 		}
 		ibmcloudObjects := stream.ReplicatedObject{
-			Regions: make(map[string]stream.RegionObject),
+			Regions: make(map[string]stream.SingleObject),
 		}
 		if releaseArch.Media.Ibmcloud.Images != nil {
 			for region, object := range releaseArch.Media.Ibmcloud.Images {
-				ri := stream.RegionObject{
+				so := stream.SingleObject{
 					Release: rel.Release,
 					Object:  object.Object,
 					Bucket:  object.Bucket,
 					Url:     object.Url,
 				}
-				ibmcloudObjects.Regions[region] = ri
+				ibmcloudObjects.Regions[region] = so
 
 			}
 			cloudImages.Ibmcloud = &ibmcloudObjects
@@ -211,17 +211,17 @@ func (releaseArch *Arch) toStreamArch(rel *Release) stream.Arch {
 			Formats: mapFormats(releaseArch.Media.PowerVS.Artifacts),
 		}
 		powervsObjects := stream.ReplicatedObject{
-			Regions: make(map[string]stream.RegionObject),
+			Regions: make(map[string]stream.SingleObject),
 		}
 		if releaseArch.Media.PowerVS.Images != nil {
 			for region, object := range releaseArch.Media.PowerVS.Images {
-				ri := stream.RegionObject{
+				so := stream.SingleObject{
 					Release: rel.Release,
 					Object:  object.Object,
 					Bucket:  object.Bucket,
 					Url:     object.Url,
 				}
-				powervsObjects.Regions[region] = ri
+				powervsObjects.Regions[region] = so
 
 			}
 			cloudImages.PowerVS = &powervsObjects

--- a/release/translate.go
+++ b/release/translate.go
@@ -138,8 +138,9 @@ func (releaseArch *Arch) toStreamArch(rel *Release) stream.Arch {
 			Formats: mapFormats(releaseArch.Media.KubeVirt.Artifacts),
 		}
 		if releaseArch.Media.KubeVirt.Image != nil {
-			cloudImages.KubeVirt = &stream.KubeVirtContainerDisk{
-				Image: releaseArch.Media.KubeVirt.Image.Image,
+			cloudImages.KubeVirt = &stream.SingleImage{
+				Release: rel.Release,
+				Image:   releaseArch.Media.KubeVirt.Image.Image,
 			}
 		}
 	}

--- a/stream/fixtures/fcos-stream.json
+++ b/stream/fixtures/fcos-stream.json
@@ -381,11 +381,13 @@
                     }
                 },
                 "gcp": {
+                    "release": "33.20201201.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
                     "name": "fedora-coreos-33-20201201-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
+                    "release": "33.20211201.3.0",
                     "image": "quay.io/openshift-release-dev/rhcos@sha256:67a81539946ec0397196c145394553b8e0241acf27b14ae9de43bc56e167f773"
                 }
             }

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -93,15 +93,20 @@ type GcpImage struct {
 	Name    string `json:"name"`
 }
 
-// ReplicatedObject represents an object in all regions of an IBMCloud-like cloud
+// ReplicatedObject represents an object in all regions of an IBMCloud-like
+// cloud
 type ReplicatedObject struct {
-	Regions map[string]RegionObject `json:"regions,omitempty"`
+	Regions map[string]SingleObject `json:"regions,omitempty"`
 }
 
-// RegionObject represents an IBMCloud/PowerVS cloud image
-type RegionObject struct {
+// SingleObject represents a globally-accessible cloud storage object, or
+// an object in a single region of an IBMCloud-like cloud
+type SingleObject struct {
 	Release string `json:"release"`
 	Object  string `json:"object"`
 	Bucket  string `json:"bucket"`
 	Url     string `json:"url"`
 }
+
+// RegionObject is a typedef for backwards compatibility.
+type RegionObject = SingleObject

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -66,11 +66,12 @@ type Images struct {
 
 // ReplicatedImage represents an image in all regions of an AWS-like cloud
 type ReplicatedImage struct {
-	Regions map[string]RegionImage `json:"regions,omitempty"`
+	Regions map[string]SingleImage `json:"regions,omitempty"`
 }
 
-// RegionImage represents an image in a single region of an AWS-like cloud
-type RegionImage struct {
+// SingleImage represents a globally-accessible image or an image in a
+// single region of an AWS-like cloud
+type SingleImage struct {
 	Release string `json:"release"`
 	Image   string `json:"image"`
 }
@@ -79,7 +80,10 @@ type RegionImage struct {
 type AwsImage = ReplicatedImage
 
 // AwsRegionImage is a typedef for backwards compatibility.
-type AwsRegionImage = RegionImage
+type AwsRegionImage = SingleImage
+
+// RegionImage is a typedef for backwards compatibility.
+type RegionImage = SingleImage
 
 // GcpImage represents a GCP cloud image
 type GcpImage struct {

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -50,18 +50,14 @@ type Artifact struct {
 	UncompressedSha256 string `json:"uncompressed-sha256,omitempty"`
 }
 
-type KubeVirtContainerDisk struct {
-	Image string `json:"image"`
-}
-
 // Images contains images available in cloud providers
 type Images struct {
-	Aliyun   *ReplicatedImage       `json:"aliyun,omitempty"`
-	Aws      *AwsImage              `json:"aws,omitempty"`
-	Gcp      *GcpImage              `json:"gcp,omitempty"`
-	Ibmcloud *ReplicatedObject      `json:"ibmcloud,omitempty"`
-	KubeVirt *KubeVirtContainerDisk `json:"kubevirt,omitempty"`
-	PowerVS  *ReplicatedObject      `json:"powervs,omitempty"`
+	Aliyun   *ReplicatedImage  `json:"aliyun,omitempty"`
+	Aws      *AwsImage         `json:"aws,omitempty"`
+	Gcp      *GcpImage         `json:"gcp,omitempty"`
+	Ibmcloud *ReplicatedObject `json:"ibmcloud,omitempty"`
+	KubeVirt *SingleImage      `json:"kubevirt,omitempty"`
+	PowerVS  *ReplicatedObject `json:"powervs,omitempty"`
 }
 
 // ReplicatedImage represents an image in all regions of an AWS-like cloud

--- a/stream/stream_utils.go
+++ b/stream/stream_utils.go
@@ -19,7 +19,7 @@ func (st *Stream) GetArchitecture(archname string) (*Arch, error) {
 
 // GetAliyunRegionImage returns the release data (Image ID and release ID) for a particular
 // architecture and region.
-func (st *Stream) GetAliyunRegionImage(archname, region string) (*RegionImage, error) {
+func (st *Stream) GetAliyunRegionImage(archname, region string) (*SingleImage, error) {
 	starch, err := st.GetArchitecture(archname)
 	if err != nil {
 		return nil, err
@@ -28,7 +28,7 @@ func (st *Stream) GetAliyunRegionImage(archname, region string) (*RegionImage, e
 	if aliyunimages == nil {
 		return nil, fmt.Errorf("%s: No Aliyun images", st.FormatPrefix(archname))
 	}
-	var regionVal RegionImage
+	var regionVal SingleImage
 	var ok bool
 	if regionVal, ok = aliyunimages.Regions[region]; !ok {
 		return nil, fmt.Errorf("%s: No Aliyun images in region %s", st.FormatPrefix(archname), region)
@@ -48,7 +48,7 @@ func (st *Stream) GetAliyunImage(archname, region string) (string, error) {
 
 // GetAwsRegionImage returns the release data (AMI and release ID) for a particular
 // architecture and region.
-func (st *Stream) GetAwsRegionImage(archname, region string) (*AwsRegionImage, error) {
+func (st *Stream) GetAwsRegionImage(archname, region string) (*SingleImage, error) {
 	starch, err := st.GetArchitecture(archname)
 	if err != nil {
 		return nil, err
@@ -57,7 +57,7 @@ func (st *Stream) GetAwsRegionImage(archname, region string) (*AwsRegionImage, e
 	if awsimages == nil {
 		return nil, fmt.Errorf("%s: No AWS images", st.FormatPrefix(archname))
 	}
-	var regionVal AwsRegionImage
+	var regionVal SingleImage
 	var ok bool
 	if regionVal, ok = awsimages.Regions[region]; !ok {
 		return nil, fmt.Errorf("%s: No AWS images in region %s", st.FormatPrefix(archname), region)


### PR DESCRIPTION
Every stream image should have a `Release` field for occasions when the recommended images aren't all at the same release.  That brings the KubeVirt structs in line with the standard ones, so just switch to those.  This is technically a compatibility break, but KubeVirt is new.

In the process, rename `RegionImage` and `RegionObject` to `SingleImage` and `SingleObject`, so they can be used on platforms with globally-namespaced images/objects.

cc @rmohr