### PR TITLE
Add digest reference to KubeVirt image description

### DIFF
--- a/release/release.go
+++ b/release/release.go
@@ -103,7 +103,7 @@ type PlatformIBMCloud struct {
 // PlatformKubeVirt containerDisk metadata
 type PlatformKubeVirt struct {
 	PlatformBase
-	Image *CloudImage `json:"image"`
+	Image *ContainerImage `json:"image"`
 }
 
 // ImageFormat contains all artifacts for a single OS image
@@ -125,6 +125,13 @@ type Artifact struct {
 // CloudImage generic image detail
 type CloudImage struct {
 	Image string `json:"image"`
+}
+
+// ContainerImage represents a tagged container image
+type ContainerImage struct {
+	// Preferred way to reference the image, which might be by tag or digest
+	Image     string `json:"image"`
+	DigestRef string `json:"digest-ref"`
 }
 
 // GcpImage represents a GCP cloud image

--- a/release/translate.go
+++ b/release/translate.go
@@ -138,9 +138,10 @@ func (releaseArch *Arch) toStreamArch(rel *Release) stream.Arch {
 			Formats: mapFormats(releaseArch.Media.KubeVirt.Artifacts),
 		}
 		if releaseArch.Media.KubeVirt.Image != nil {
-			cloudImages.KubeVirt = &stream.SingleImage{
-				Release: rel.Release,
-				Image:   releaseArch.Media.KubeVirt.Image.Image,
+			cloudImages.KubeVirt = &stream.ContainerImage{
+				Release:   rel.Release,
+				Image:     releaseArch.Media.KubeVirt.Image.Image,
+				DigestRef: releaseArch.Media.KubeVirt.Image.DigestRef,
 			}
 		}
 	}

--- a/stream/fixtures/fcos-stream.json
+++ b/stream/fixtures/fcos-stream.json
@@ -388,7 +388,8 @@
                 },
                 "kubevirt": {
                     "release": "33.20211201.3.0",
-                    "image": "quay.io/openshift-release-dev/rhcos@sha256:67a81539946ec0397196c145394553b8e0241acf27b14ae9de43bc56e167f773"
+                    "image": "quay.io/openshift-release-dev/rhcos:latest",
+                    "digest-ref": "quay.io/openshift-release-dev/rhcos@sha256:67a81539946ec0397196c145394553b8e0241acf27b14ae9de43bc56e167f773"
                 }
             }
         }

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -56,7 +56,7 @@ type Images struct {
 	Aws      *AwsImage         `json:"aws,omitempty"`
 	Gcp      *GcpImage         `json:"gcp,omitempty"`
 	Ibmcloud *ReplicatedObject `json:"ibmcloud,omitempty"`
-	KubeVirt *SingleImage      `json:"kubevirt,omitempty"`
+	KubeVirt *ContainerImage   `json:"kubevirt,omitempty"`
 	PowerVS  *ReplicatedObject `json:"powervs,omitempty"`
 }
 
@@ -70,6 +70,14 @@ type ReplicatedImage struct {
 type SingleImage struct {
 	Release string `json:"release"`
 	Image   string `json:"image"`
+}
+
+// ContainerImage represents a tagged container image
+type ContainerImage struct {
+	Release string `json:"release"`
+	// Preferred way to reference the image, which might be by tag or digest
+	Image     string `json:"image"`
+	DigestRef string `json:"digest-ref"`
 }
 
 // AwsImage is a typedef for backwards compatibility.

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -64,6 +64,10 @@ func TestParseFCS(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "does not have architecture 'nonarch'")
 
-	assert.Equal(t, stream.Architectures["x86_64"].Images.KubeVirt.Image, "quay.io/openshift-release-dev/rhcos@sha256:67a81539946ec0397196c145394553b8e0241acf27b14ae9de43bc56e167f773")
+	assert.Equal(t, stream.Architectures["x86_64"].Images.KubeVirt, &ContainerImage{
+		Release:   "33.20211201.3.0",
+		Image:     "quay.io/openshift-release-dev/rhcos@latest",
+		DigestRef: "quay.io/openshift-release-dev/rhcos@sha256:67a81539946ec0397196c145394553b8e0241acf27b14ae9de43bc56e167f773",
+	})
 	assert.Equal(t, stream.Architectures["x86_64"].Artifacts["kubevirt"].Formats["qcow2.xz"].Disk.Sha256, "2be55c5aa1f53eb9a869826dacbab75706ee6bd59185b935ac9be546cc132a85")
 }


### PR DESCRIPTION
In the current design, the KubeVirt image is presumed to be a fully-qualified reference, including a container digest.  But that implies that the user should reference the image by digest, when we'd prefer that they reference it by stream-specific tag.

Define the existing `image` field to contain the preferred form of fully-qualified reference for the image, which might involve either a
tag or a digest.  We should still record the unique identifier of the current image (as we do for GCP images), so add a `digest-ref` field which always contains a fully-qualified reference with digest.

cc @rmohr @dustymabe 