### PR TITLE
Bump minimum Go version to 1.18

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     name: test build
     strategy:
       matrix:
-        go-version: [1.17.x, 1.18.x, 1.19.x]
+        go-version: [1.18.x, 1.19.x]
         os: [ubuntu-latest]
         include:
         - go-version: 1.19.x

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coreos/stream-metadata-go
 
-go 1.17
+go 1.18
 
 require github.com/stretchr/testify v1.8.1
 


### PR DESCRIPTION
Go 1.17 is EOL.