### PR TITLE
Update kubevirt platform format

### DIFF
--- a/release/fixtures/fcos-release.json
+++ b/release/fixtures/fcos-release.json
@@ -203,10 +203,10 @@
         },
         "kubevirt": {
           "artifacts": {
-            "qcow2.xz": {
+            "ociarchive": {
               "disk": {
-                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20201201.3.0/x86_64/fedora-coreos-33.20201201.3.0-kubevirt.x86_64.qcow2.xz",
-                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20201201.3.0/x86_64/fedora-coreos-33.20201201.3.0-kubevirt.x86_64.qcow2.xz.sig",
+                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20201201.3.0/x86_64/fedora-coreos-33.20201201.3.0-kubevirt.x86_64.ociarchive",
+                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20201201.3.0/x86_64/fedora-coreos-33.20201201.3.0-kubevirt.x86_64.ociarchive.sig",
                 "sha256": "2be55c5aa1f53eb9a869826dacbab75706ee6bd59185b935ac9be546cc132a85"
               }
             }

--- a/stream/fixtures/fcos-stream.json
+++ b/stream/fixtures/fcos-stream.json
@@ -149,10 +149,10 @@
                 "kubevirt": {
                     "release": "33.20201201.3.0",
                     "formats": {
-                        "qcow2.xz": {
+                        "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20201201.3.0/x86_64/fedora-coreos-33.20201201.3.0-kubevirt.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20201201.3.0/x86_64/fedora-coreos-33.20201201.3.0-kubevirt.x86_64.qcow2.xz.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20201201.3.0/x86_64/fedora-coreos-33.20201201.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20201201.3.0/x86_64/fedora-coreos-33.20201201.3.0-kubevirt.x86_64.ociarchive.sig",
                                 "sha256": "2be55c5aa1f53eb9a869826dacbab75706ee6bd59185b935ac9be546cc132a85"
                             }
                         }

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -69,5 +69,5 @@ func TestParseFCS(t *testing.T) {
 		Image:     "quay.io/openshift-release-dev/rhcos:latest",
 		DigestRef: "quay.io/openshift-release-dev/rhcos@sha256:67a81539946ec0397196c145394553b8e0241acf27b14ae9de43bc56e167f773",
 	})
-	assert.Equal(t, stream.Architectures["x86_64"].Artifacts["kubevirt"].Formats["qcow2.xz"].Disk.Sha256, "2be55c5aa1f53eb9a869826dacbab75706ee6bd59185b935ac9be546cc132a85")
+	assert.Equal(t, stream.Architectures["x86_64"].Artifacts["kubevirt"].Formats["ociarchive"].Disk.Sha256, "2be55c5aa1f53eb9a869826dacbab75706ee6bd59185b935ac9be546cc132a85")
 }


### PR DESCRIPTION
Seeing that we get an `ociarchive` artifact after we `cosa buildextend-kubevirt`, we need to update the format in the `fcos-release.json` and `fcos-stream.json` in addition to stream_test.go.