### PR TITLE
Add AppleHV artifact to stream and release metadata

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,7 +4,7 @@
 
 Changes:
 
-
+- Add support for AppleHV images
 
 ## stream-metadata-go 0.4.3 (2023-06-28)
 

--- a/release/release.go
+++ b/release/release.go
@@ -53,6 +53,7 @@ type Arch struct {
 // Media contains release details for various platforms
 type Media struct {
 	Aliyun       *PlatformAliyun   `json:"aliyun"`
+	AppleHV      *PlatformBase     `json:"applehv"`
 	Aws          *PlatformAws      `json:"aws"`
 	Azure        *PlatformBase     `json:"azure"`
 	AzureStack   *PlatformBase     `json:"azurestack"`

--- a/release/translate.go
+++ b/release/translate.go
@@ -58,6 +58,13 @@ func (releaseArch *Arch) toStreamArch(rel *Release) stream.Arch {
 		}
 	}
 
+	if releaseArch.Media.AppleHV != nil {
+		artifacts["applehv"] = stream.PlatformArtifacts{
+			Release: rel.Release,
+			Formats: mapFormats(releaseArch.Media.AppleHV.Artifacts),
+		}
+	}
+
 	if releaseArch.Media.Aws != nil {
 		artifacts["aws"] = stream.PlatformArtifacts{
 			Release: rel.Release,


### PR DESCRIPTION
Satisfying coreos/fedora-coreos-tracker#1533 and
coreos/fedora-coreos-tracker#1548