### PR TITLE
release: support OCI image pullspecs

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -5,6 +5,8 @@
 Changes:
 
 - Bump minimum supported Go version to 1.22
+- Add `Arch.OciImage` field to release metadata containing base OS OCI image
+- Add `OciImages` field to release index containing base OS OCI images
 
 ## stream-metadata-go 0.4.4 (2023-11-28)
 

--- a/release/fixtures/fcos-release.json
+++ b/release/fixtures/fcos-release.json
@@ -249,7 +249,11 @@
           }
         }
       },
-      "commit": "cad80088392fe43bd3cadf0481c3267f199afa7d9f83bc03937ffdbf5ebbc6da"
+      "commit": "cad80088392fe43bd3cadf0481c3267f199afa7d9f83bc03937ffdbf5ebbc6da",
+      "oci-image": {
+        "image": "quay.io/fedora/fedora-coreos:stable",
+        "digest-ref": "quay.io/fedora/fedora-coreos@sha256:460576931cf4ce59afe432ea266234f9d34fa77f8ca3087282084bc3a7324632"
+      }
     }
   }
 }

--- a/release/fixtures/fcos-releases.json
+++ b/release/fixtures/fcos-releases.json
@@ -8,6 +8,13 @@
           "checksum": "113aa27efe1bbcf6324af7423f64ef7deb0acbf21b928faec84bf66a60a5c933"
         }
       ],
+      "oci-images": [
+        {
+          "architecture": "x86_64",
+          "image": "quay.io/fedora/fedora-coreos:stable",
+          "digest-ref": "quay.io/fedora/fedora-coreos@sha256:460576931cf4ce59afe432ea266234f9d34fa77f8ca3087282084bc3a7324632"
+        }
+      ],
       "version": "31.20200108.3.0",
       "metadata": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200108.3.0/release.json"
     },

--- a/release/release.go
+++ b/release/release.go
@@ -19,15 +19,22 @@ type Index struct {
 
 // IndexRelease is a "release pointer" from a release index
 type IndexRelease struct {
-	Commits     []IndexReleaseCommit `json:"commits"`
-	Version     string               `json:"version"`
-	MetadataURL string               `json:"metadata"`
+	Commits     []IndexReleaseCommit   `json:"commits"`
+	OciImages   []IndexReleaseOciImage `json:"oci-images,omitempty"`
+	Version     string                 `json:"version"`
+	MetadataURL string                 `json:"metadata"`
 }
 
 // IndexReleaseCommit describes an ostree commit plus architecture
 type IndexReleaseCommit struct {
 	Architecture string `json:"architecture"`
 	Checksum     string `json:"checksum"`
+}
+
+// IndexReleaseOciImages describes a pullspec plus architecture
+type IndexReleaseOciImage struct {
+	ContainerImage
+	Architecture string `json:"architecture"`
 }
 
 // Release contains details from release.json
@@ -46,6 +53,7 @@ type Metadata struct {
 // Arch release details
 type Arch struct {
 	Commit               string               `json:"commit"`
+	OciImage             *ContainerImage      `json:"oci-image,omitempty"`
 	Media                Media                `json:"media"`
 	RHELCoreOSExtensions *relrhcos.Extensions `json:"rhel-coreos-extensions,omitempty"`
 }

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -22,6 +22,8 @@ func TestParseFCR(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, release.Stream, "stable")
 	assert.Equal(t, release.Architectures["x86_64"].Media.Aws.Images["us-east-2"].Image, usEast2Ami)
+	assert.Equal(t, release.Architectures["x86_64"].OciImage.Image, "quay.io/fedora/fedora-coreos:stable")
+	assert.Equal(t, release.Architectures["x86_64"].OciImage.DigestRef, "quay.io/fedora/fedora-coreos@sha256:460576931cf4ce59afe432ea266234f9d34fa77f8ca3087282084bc3a7324632")
 }
 
 func TestParseFCRIndex(t *testing.T) {
@@ -35,6 +37,8 @@ func TestParseFCRIndex(t *testing.T) {
 	assert.Equal(t, release.Version, "31.20200108.3.0")
 	assert.Equal(t, release.Commits[0].Architecture, "x86_64")
 	assert.Equal(t, release.Commits[0].Checksum, "113aa27efe1bbcf6324af7423f64ef7deb0acbf21b928faec84bf66a60a5c933")
+	assert.Equal(t, release.OciImages[0].Image, "quay.io/fedora/fedora-coreos:stable")
+	assert.Equal(t, release.OciImages[0].DigestRef, "quay.io/fedora/fedora-coreos@sha256:460576931cf4ce59afe432ea266234f9d34fa77f8ca3087282084bc3a7324632")
 }
 
 func TestTranslate(t *testing.T) {


### PR DESCRIPTION
Add support in both release metadata and the release index for specifying OCI image pullspecs for a given release. In both cases, the new fields are located at the same level as the existing `commits` key holding OSTree checksums.

The key is called `oci-image` in release metadata and `oci-images` in the release index.

Part of https://github.com/coreos/fedora-coreos-tracker/issues/1823.