### PR TITLE
Add AWS WinLI images to RHELCoreOSExtensions

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,8 @@
 
 ## Upcoming stream-metadata-go 0.4.7 (unreleased)
 
+- Add support for AWS Windows License Included images
+
 ## stream-metadata-go 0.4.6 (2025-03-25)
 
 Changes:

--- a/release/rhcos/rhcos.go
+++ b/release/rhcos/rhcos.go
@@ -2,6 +2,7 @@ package rhcos
 
 // Extensions is data specific to Red Hat Enterprise Linux CoreOS
 type Extensions struct {
+	AwsWinLi  *AwsWinLi  `json:"aws-winli,omitempty"`
 	AzureDisk *AzureDisk `json:"azure-disk,omitempty"`
 }
 
@@ -11,4 +12,19 @@ type AzureDisk struct {
 	// that can be copied into an image gallery.  Avoid creating VMs directly
 	// from this URL as that may lead to performance limitations.
 	URL string `json:"url,omitempty"`
+}
+
+// AwsWinLi represents prebuilt AWS Windows License Included Images.
+type AwsWinLi struct {
+	// A mapping of AWS region names (e.g. "us-east-1") to CloudImage
+	// descriptors. Each entry provides metadata for the corresponding
+	// AWS Windows LI AMI.
+	Images map[string]CloudImage `json:"images"`
+}
+
+// CloudImage generic image detail
+// This struct was copied from the release package to avoid an import cycle,
+// and is used to describe individual AWS WinLI Images.
+type CloudImage struct {
+	Image string `json:"image"`
 }

--- a/release/translate.go
+++ b/release/translate.go
@@ -81,6 +81,21 @@ func (releaseArch *Arch) toStreamArch(rel *Release) stream.Arch {
 			}
 			cloudImages.Aws = &awsAmis
 		}
+
+		if relRHCOSExt != nil {
+			if relRHCOSExt.AwsWinLi != nil {
+				if relRHCOSExt.AwsWinLi.Images != nil {
+					awsWinLIAmis := rhcos.ReplicatedImage{
+						Regions: make(map[string]rhcos.SingleImage),
+					}
+					for region, ami := range relRHCOSExt.AwsWinLi.Images {
+						si := rhcos.SingleImage{Release: rel.Release, Image: ami.Image}
+						awsWinLIAmis.Regions[region] = si
+					}
+					rhcosExt.AwsWinLi = &awsWinLIAmis
+				}
+			}
+		}
 	}
 
 	if releaseArch.Media.Azure != nil {

--- a/stream/rhcos/rhcos.go
+++ b/stream/rhcos/rhcos.go
@@ -2,6 +2,7 @@ package rhcos
 
 // Extensions is data specific to Red Hat Enterprise Linux CoreOS
 type Extensions struct {
+	AwsWinLi  *AwsWinLi  `json:"aws-winli,omitempty"`
 	AzureDisk *AzureDisk `json:"azure-disk,omitempty"`
 }
 
@@ -15,4 +16,23 @@ type AzureDisk struct {
 	// that can be copied into an image gallery.  Avoid creating VMs directly
 	// from this URL as that may lead to performance limitations.
 	URL string `json:"url,omitempty"`
+}
+
+// AwsWinLi represents prebuilt AWS Windows License Included Images.
+type AwsWinLi = ReplicatedImage
+
+// ReplicatedImage represents an image in all regions of an AWS-like cloud
+// This struct was copied from the release package to avoid an import cycle,
+// and is used to describe all AWS WinLI Images in all regions.
+type ReplicatedImage struct {
+	Regions map[string]SingleImage `json:"regions,omitempty"`
+}
+
+// SingleImage represents a globally-accessible image or an image in a
+// single region of an AWS-like cloud
+// This struct was copied from the release package to avoid an import cycle,
+// and is used to describe individual AWS WinLI Images.
+type SingleImage struct {
+	Release string `json:"release"`
+	Image   string `json:"image"`
 }


### PR DESCRIPTION
Add image information for AWS Windows License Included images to both
release and stream RHELCoreOSExtensions structs. Also add logic to
translate the AWS WinLI release metadata into stream metadata.

See: https://issues.redhat.com/browse/COS-3057

This is needed before https://github.com/coreos/coreos-assembler/pull/4069 lands