### PR TITLE
Add marketplace extension

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,7 +4,7 @@
 
 Changes:
 
-- Change 1
+- Add support for cloud marketplace images
 
 ## stream-metadata-go 0.4.9 (2025-07-18)
 

--- a/stream/rhcos/rhcos.go
+++ b/stream/rhcos/rhcos.go
@@ -1,9 +1,12 @@
 package rhcos
 
+import "fmt"
+
 // Extensions is data specific to Red Hat Enterprise Linux CoreOS
 type Extensions struct {
-	AwsWinLi  *AwsWinLi  `json:"aws-winli,omitempty"`
-	AzureDisk *AzureDisk `json:"azure-disk,omitempty"`
+	AwsWinLi    *AwsWinLi    `json:"aws-winli,omitempty"`
+	AzureDisk   *AzureDisk   `json:"azure-disk,omitempty"`
+	Marketplace *Marketplace `json:"marketplace,omitempty"`
 }
 
 // AzureDisk represents an Azure disk image that can be imported
@@ -35,4 +38,55 @@ type ReplicatedImage struct {
 type SingleImage struct {
 	Release string `json:"release"`
 	Image   string `json:"image"`
+}
+
+// Marketplace contains marketplace images for all clouds.
+type Marketplace struct {
+	Azure *AzureMarketplace `json:"azure,omitempty"`
+}
+
+// AzureMarketplaceImages contains both the HyperV- Gen1 & Gen2
+// images for a purchase plan.
+type AzureMarketplaceImages struct {
+	Gen1 *AzureMarketplaceImage `json:"hyperVGen1,omitempty"`
+	Gen2 *AzureMarketplaceImage `json:"hyperVGen2,omitempty"`
+}
+
+// AzureMarketplace lists images, both paid and
+// unpaid, available in the Azure marketplace.
+type AzureMarketplace struct {
+	// NoPurchasePlan is the standard, unpaid RHCOS image.
+	NoPurchasePlan *AzureMarketplaceImages `json:"no-purchase-plan,omitempty"`
+
+	// OCP is the paid marketplace image for OpenShift Container Platform.
+	OCP *AzureMarketplaceImages `json:"ocp,omitempty"`
+
+	// OPP is the paid marketplace image for OpenShift Platform Plus.
+	OPP *AzureMarketplaceImages `json:"opp,omitempty"`
+
+	// OKE is the paid marketplace image for OpenShift Kubernetes Engine.
+	OKE *AzureMarketplaceImages `json:"oke,omitempty"`
+
+	// OCPEMEA is the paid marketplace image for OpenShift Container Platform in EMEA regions.
+	OCPEMEA *AzureMarketplaceImages `json:"ocp-emea,omitempty"`
+
+	// OPPEMEA is the paid marketplace image for OpenShift Platform Plus in EMEA regions.
+	OPPEMEA *AzureMarketplaceImages `json:"opp-emea,omitempty"`
+
+	// OKEEMEA is the paid marketplace image for OpenShift Kubernetes Engine in EMEA regions.
+	OKEEMEA *AzureMarketplaceImages `json:"oke-emea,omitempty"`
+}
+
+// AzureMarketplaceImage defines the attributes for an Azure
+// marketplace image.
+type AzureMarketplaceImage struct {
+	Publisher string `json:"publisher"`
+	Offer     string `json:"offer"`
+	SKU       string `json:"sku"`
+	Version   string `json:"version"`
+}
+
+// URN returns the image URN for the marketplace image.
+func (i *AzureMarketplaceImage) URN() string {
+	return fmt.Sprintf("%s:%s:%s:%s", i.Publisher, i.Offer, i.SKU, i.Version)
 }


### PR DESCRIPTION
Adds a marketplace extension to contain cloud marketplace offerings, which would be updated by a separate process (than the rhcos.json stream publishing). Initially, the API is only defined for Azure, but AWS & GCP will be subsequently added.

See https://github.com/openshift/enhancements/pull/1655 for more details and discussion.