### PR TITLE
release: support missing ostree commits

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,10 @@
 
 ## Upcoming stream-metadata-go 0.4.6 (unreleased)
 
+Changes:
+
+- Don't serialize missing OSTree commits in both release and release index metadata
+
 ## stream-metadata-go 0.4.5 (2024-11-05)
 
 Changes:

--- a/release/release.go
+++ b/release/release.go
@@ -19,7 +19,7 @@ type Index struct {
 
 // IndexRelease is a "release pointer" from a release index
 type IndexRelease struct {
-	Commits     []IndexReleaseCommit   `json:"commits"`
+	Commits     []IndexReleaseCommit   `json:"commits,omitempty"`
 	OciImages   []IndexReleaseOciImage `json:"oci-images,omitempty"`
 	Version     string                 `json:"version"`
 	MetadataURL string                 `json:"metadata"`
@@ -52,7 +52,7 @@ type Metadata struct {
 
 // Arch release details
 type Arch struct {
-	Commit               string               `json:"commit"`
+	Commit               string               `json:"commit,omitempty"`
 	OciImage             *ContainerImage      `json:"oci-image,omitempty"`
 	Media                Media                `json:"media"`
 	RHELCoreOSExtensions *relrhcos.Extensions `json:"rhel-coreos-extensions,omitempty"`


### PR DESCRIPTION
FCOS at least doesn't ship using OSTree anymore, so allow the field to be empty.